### PR TITLE
A couple of useful changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 module1 = Extension('lru',
                     sources = ['lru.c'])


### PR DESCRIPTION
- Fix a bug with the linked list bookkeeping when using subscript.
  (last isn't updated at https://github.com/amitdev/lru-dict/blob/5c5be1248fed51fd4d3468aec8d18cf550df7d5c/lru.c#L153 )
  Given this is not the first bug of this kind, I added 2 helper methods that operate on the linked list. Nothing else operates on the list directly.
- Properly INCREF the key when storing it in the node object.
- Small refactoring - stop using X{INC,DEC}REF when arguments should be non-null, add asserts, kill OBJ_INCRFED which is non-portable.
- Do the correct thing when overwriting a value as opposed to corrupting memory.
- Slightly more efficient LRU_clear implementation.
