### PR TITLE
Don't move the node when it's self->first.

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -195,15 +195,18 @@ static PyObject *
 lru_subscript(LRU *self, register PyObject *key)
 {
     Node *node = GET_NODE(self->dict, key);
-    if (node == NULL) {
+    if (!node) {
         self->misses++;
         return NULL;
     }
 
     assert(PyObject_TypeCheck(node, &NodeType));
 
-    lru_remove_node(self, node);
-    lru_add_node_at_head(self, node);
+    /* We don't need to move the node when it's already self->first. */
+    if (node != self->first) {
+        lru_remove_node(self, node);
+        lru_add_node_at_head(self, node);
+    }
 
     self->hits++;
     Py_INCREF(node->value);

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -194,5 +194,36 @@ class TestLRU(unittest.TestCase):
             self.assertTrue(len(l) == 0)
             self.assertTrue(l.get_stats() == (0, 0))
 
+    def test_lru(self):
+        l = LRU(1)
+        l['a'] = 1
+        l['a']
+        self.assertEqual(l.keys(), ['a'])
+        l['b'] = 2
+        self.assertEqual(l.keys(), ['b'])
+
+        l = LRU(2)
+        l['a'] = 1
+        l['b'] = 2
+        self.assertEqual(len(l), 2)
+        l['a']                  # Testing the first one
+        l['c'] = 3
+        self.assertEqual(sorted(l.keys()), ['a', 'c'])
+        l['c']
+        self.assertEqual(sorted(l.keys()), ['a', 'c'])
+
+        l = LRU(3)
+        l['a'] = 1
+        l['b'] = 2
+        l['c'] = 3
+        self.assertEqual(len(l), 3)
+        l['b']                  # Testing the middle one
+        l['d'] = 4
+        self.assertEqual(sorted(l.keys()), ['b', 'c', 'd'])
+        l['d']                  # Testing the last one
+        self.assertEqual(sorted(l.keys()), ['b', 'c', 'd'])
+        l['e'] = 5
+        self.assertEqual(sorted(l.keys()), ['b', 'd', 'e'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We don't need to change anything in the double linked list if there is
only one node or if we are already self->first.

* No node shuffling if there is only one node or we are already self->first