### PR TITLE
clear KeyError in LRU_get

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -225,6 +225,7 @@ LRU_get(LRU *self, PyObject *args)
         return NULL;
     
     result = lru_subscript(self, key);
+    PyErr_Clear();  /* GET_NODE sets an exception on miss. Shut it up. */
     if (result)
         return result;
 


### PR DESCRIPTION
Hi,

This fixes a bug in LRU_get, reproducible like this:

    Python 2.7.5 (default, Oct 29 2013, 22:46:38) 
    [GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import lru
    >>> p = lru.LRU(10)
    >>> p.get('test')
    >>> 
    KeyError: 'test'
