### PR TITLE
Adds optional callback for when an item is evicted from the cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,27 @@ This can be used to build a LRU cache. Usage is almost like a dict.
   print l.items()
   # Would print []
 
+  def evicted(key, value):
+    print "removing: %s, %s" % (key, value)
+
+  l = LRU(1, callback=evicted)
+
+  l[1] = '1'
+  l[2] = '2'
+  # callback would print removing: 1, 1
+
+  l[2] = '3'
+  # doesn't call the evicted callback
+
+  print l.items()
+  # would print [(2, '3')]
+  
+  del l[2]
+  # doesn't call the evicted callback
+
+  print l.items()
+  # would print []
+
 Install
 =======
 

--- a/lru.c
+++ b/lru.c
@@ -149,9 +149,7 @@ set_callback(LRU *self, PyObject *args)
             Py_XDECREF(self->callback);  /* Dispose of previous callback */
             self->callback = temp;       /* Remember new callback */
         }
-        /* Boilerplate to return "None" */
-        Py_INCREF(Py_None);
-        result = Py_None;
+        Py_RETURN_NONE;
     }
     return result;
 }

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -271,5 +271,35 @@ class TestLRU(unittest.TestCase):
         l['e'] = 5
         self.assertEqual(sorted(l.keys()), ['b', 'd', 'e'])
 
+    def test_callback(self):
+
+        counter = [0]
+
+        first_key = 'a'
+        first_value = 1
+
+        def callback(key, value):
+            self.assertEqual(key, first_key)
+            self.assertEqual(value, first_value)
+            counter[0] += 1
+
+        l = LRU(1, callback=callback)
+        l[first_key] = first_value
+        l['b'] = 1
+
+        self.assertEqual(counter[0], 1)
+        self.assertEqual(l.keys(), ['b'])
+
+        l['b'] = 2
+        self.assertEqual(counter[0], 1)
+        self.assertEqual(l.keys(), ['b'])
+        self.assertEqual(l.values(), [2])
+
+        l.set_callback(None)
+        l['c'] = 1
+        self.assertEqual(counter[0], 1)
+        self.assertEqual(l.keys(), ['c'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -285,20 +285,28 @@ class TestLRU(unittest.TestCase):
 
         l = LRU(1, callback=callback)
         l[first_key] = first_value
-        l['b'] = 1
+        l['b'] = 1              # test calling the callback
 
         self.assertEqual(counter[0], 1)
         self.assertEqual(l.keys(), ['b'])
 
-        l['b'] = 2
+        l['b'] = 2              # doesn't call callback
         self.assertEqual(counter[0], 1)
         self.assertEqual(l.keys(), ['b'])
         self.assertEqual(l.values(), [2])
 
+
+        l = LRU(1, callback=callback)
+        l[first_key] = first_value
+
         l.set_callback(None)
-        l['c'] = 1
+        l['c'] = 1              # doesn't call callback
         self.assertEqual(counter[0], 1)
         self.assertEqual(l.keys(), ['c'])
+
+        l.set_callback(callback)
+        del l['c']              # doesn't call callback
+        self.assertEqual(l.keys(), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We were using a pure python LRU cache that had an optional callback when an item is added.  This adds that feature to lru-dict. 

Tested with python 2.7.9 on CentOS 7 and Windows 10.  