### PR TITLE
Fix reference count for return value of LRU.setdefault().

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -409,6 +409,8 @@ LRU_setdefault(LRU *self, PyObject *args)
 
     if (lru_ass_sub(self, key, default_obj) != 0)
         return NULL;
+
+    Py_INCREF(default_obj);
     return default_obj;
 }
 

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -222,6 +222,12 @@ class TestLRU(unittest.TestCase):
         self.assertEqual('2', val)
         self.assertEqual((1, 1), l.get_stats())
         self.assertEqual(val, l[2])
+        l.clear()
+        val = 'long string' * 512
+        l.setdefault(1, val)
+        l[2] = '2'
+        l[3] = '3'
+        self.assertTrue(val)
 
     def test_stats(self):
         for size in SIZES:


### PR DESCRIPTION
In commit a90f68fe, the `setdefault()` method was implemented. However,
the reference to the return value is stolen by the function and can be
lost when the referent is released. This is not the intended behaviour
and can crash Python because of garbage collection.

This is fixed by donating reference to the caller.