### PR TITLE
Implement pop

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -427,22 +427,11 @@ LRU_pop(LRU *self, PyObject *args)
     /* Trying to access the item by key. */
     result = lru_subscript(self, key);
 
-    if (result) {
-        /* Save and restore Python error indicator around deleting item --
-         * because between the last call of item getter (lru_subscript) and
-         * next call of item setter (lru_ass_sub), the item may have been
-         * removed from the LRU as the effect of arbitrary action in code
-         * elsewhere, thus incurring an error that will not be cleared by us.
-         */
-
-        /* Question: does this matter in the current implementation? */
-        PyObject *e_type, *e_value, *e_traceback;
-
-        PyErr_Fetch(&e_type, &e_value, &e_traceback);
+    if (result)
+        /* result != NULL, delete it from dict by key */
         lru_ass_sub(self, key, NULL);
-	PyErr_Restore(e_type, e_value, e_traceback);
-    } else if (default_obj) {
-	/* result == NULL, i.e. key missing, and default_obj given */
+    else if (default_obj) {
+        /* result == NULL, i.e. key missing, and default_obj given */
         PyErr_Clear();
         Py_INCREF(default_obj);
         result = default_obj;

--- a/lru.c
+++ b/lru.c
@@ -409,6 +409,8 @@ LRU_setdefault(LRU *self, PyObject *args)
 
     if (lru_ass_sub(self, key, default_obj) != 0)
         return NULL;
+
+    Py_INCREF(default_obj);
     return default_obj;
 }
 

--- a/lru.c
+++ b/lru.c
@@ -424,6 +424,7 @@ LRU_pop(LRU *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O|O", &key, &default_obj))
         return NULL;
 
+    /* Trying to access the item by key. */
     result = lru_subscript(self, key);
 
     if (result) {
@@ -441,10 +442,15 @@ LRU_pop(LRU *self, PyObject *args)
         lru_ass_sub(self, key, NULL);
 	PyErr_Restore(e_type, e_value, e_traceback);
     } else if (default_obj) {
+	/* result == NULL, i.e. key missing, and default_obj given */
         PyErr_Clear();
         Py_INCREF(default_obj);
         result = default_obj;
     }
+    /* Otherwise (key missing, and default_obj not given [i.e. == NULL]), the
+     * call to lru_subscript (at the location marked by "Trying to access the
+     * item by key" in the comments) has already generated the appropriate
+     * exception. */
 
     return result;
 }

--- a/lru.c
+++ b/lru.c
@@ -415,6 +415,41 @@ LRU_setdefault(LRU *self, PyObject *args)
 }
 
 static PyObject *
+LRU_pop(LRU *self, PyObject *args)
+{
+    PyObject *key;
+    PyObject *default_obj = NULL;
+    PyObject *result;
+
+    if (!PyArg_ParseTuple(args, "O|O", &key, &default_obj))
+        return NULL;
+
+    result = lru_subscript(self, key);
+
+    if (result) {
+        /* Save and restore Python error indicator around deleting item --
+         * because between the last call of item getter (lru_subscript) and
+         * next call of item setter (lru_ass_sub), the item may have been
+         * removed from the LRU as the effect of arbitrary action in code
+         * elsewhere, thus incurring an error that will not be cleared by us.
+         */
+
+        /* Question: does this matter in the current implementation? */
+        PyObject *e_type, *e_value, *e_traceback;
+
+        PyErr_Fetch(&e_type, &e_value, &e_traceback);
+        lru_ass_sub(self, key, NULL);
+	PyErr_Restore(e_type, e_value, e_traceback);
+    } else if (default_obj) {
+        PyErr_Clear();
+        Py_INCREF(default_obj);
+        result = default_obj;
+    }
+
+    return result;
+}
+
+static PyObject *
 LRU_peek_first_item(LRU *self)
 {
     if (self->first) {
@@ -561,6 +596,8 @@ static PyMethodDef LRU_methods[] = {
                     PyDoc_STR("L.get(key, instead) -> If L has key return its value, otherwise instead")},
     {"setdefault", (PyCFunction)LRU_setdefault, METH_VARARGS,
                     PyDoc_STR("L.setdefault(key, default=None) -> If L has key return its value, otherwise insert key with a value of default and return default")},
+    {"pop", (PyCFunction)LRU_pop, METH_VARARGS,
+                    PyDoc_STR("L.pop(key[, default]) -> If L has key return its value and remove it from L, otherwise return default. If default is not given and key is not in L, a KeyError is raised.")},
     {"set_size", (PyCFunction)LRU_set_size, METH_VARARGS,
                     PyDoc_STR("L.set_size() -> set size of LRU")},
     {"get_size", (PyCFunction)LRU_get_size, METH_NOARGS,

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -9,6 +9,7 @@ SIZES = [1, 2, 10, 1000]
 # Only available on debug python builds.
 gettotalrefcount = getattr(sys, 'gettotalrefcount', lambda: 0)
 
+
 class TestLRU(unittest.TestCase):
 
     def setUp(self):
@@ -40,33 +41,33 @@ class TestLRU(unittest.TestCase):
             l = LRU(size)
             for i in range(size):
                 l[i] = str(i)
-            self._check_kvi(range(size-1,-1,-1), l)
+            self._check_kvi(range(size - 1, -1, -1), l)
 
     def test_delete_multiple_within_size(self):
         for size in SIZES:
             l = LRU(size)
             for i in range(size):
                 l[i] = str(i)
-            for i in range(0,size,2):
+            for i in range(0, size, 2):
                 del l[i]
-            self._check_kvi(range(size-1,0,-2), l)
-            for i in range(0,size,2):
+            self._check_kvi(range(size - 1, 0, -2), l)
+            for i in range(0, size, 2):
                 with self.assertRaises(KeyError):
                     l[i]
 
     def test_delete_multiple(self):
         for size in SIZES:
             l = LRU(size)
-            n = size*2
+            n = size * 2
             for i in range(n):
                 l[i] = str(i)
-            for i in range(size,n,2):
+            for i in range(size, n, 2):
                 del l[i]
-            self._check_kvi(range(n-1,size,-2), l)
-            for i in range(0,size):
+            self._check_kvi(range(n - 1, size, -2), l)
+            for i in range(0, size):
                 with self.assertRaises(KeyError):
                     l[i]
-            for i in range(size,n,2):
+            for i in range(size, n, 2):
                 with self.assertRaises(KeyError):
                     l[i]
 
@@ -76,7 +77,7 @@ class TestLRU(unittest.TestCase):
             for i in range(size):
                 l[i] = str(i)
             l[size] = str(size)
-            self._check_kvi(range(size,0,-1), l)
+            self._check_kvi(range(size, 0, -1), l)
 
     def test_access_within_size(self):
         for size in SIZES:
@@ -85,7 +86,7 @@ class TestLRU(unittest.TestCase):
                 l[i] = str(i)
             for i in range(size):
                 self.assertEqual(l[i], str(i))
-                self.assertEqual(l.get(i,None), str(i))
+                self.assertEqual(l.get(i, None), str(i))
 
     def test_contains(self):
         for size in SIZES:
@@ -101,11 +102,10 @@ class TestLRU(unittest.TestCase):
             n = size * 2
             for i in range(n):
                 l[i] = str(i)
-            self._check_kvi(range(n-1,size-1,-1), l)
+            self._check_kvi(range(n - 1, size - 1, -1), l)
             for i in range(size, n):
                 self.assertEqual(l[i], str(i))
-                self.assertEqual(l.get(i,None), str(i))
-
+                self.assertEqual(l.get(i, None), str(i))
 
     def test_update(self):
         l = LRU(2)
@@ -119,7 +119,7 @@ class TestLRU(unittest.TestCase):
         self.assertEqual(('b', 3), l.peek_first_item())
         self.assertEqual(l['a'], 2)
         self.assertEqual(l['b'], 3)
-        l.update({'a':1, 'b':2})
+        l.update({'a': 1, 'b': 2})
         self.assertEqual(('b', 2), l.peek_first_item())
         self.assertEqual(l['a'], 1)
         self.assertEqual(l['b'], 2)
@@ -127,7 +127,6 @@ class TestLRU(unittest.TestCase):
         self.assertEqual(('b', 2), l.peek_first_item())
         l.update(a=2)
         self.assertEqual(('a', 2), l.peek_first_item())
-
 
     def test_peek_first_item(self):
         l = LRU(2)
@@ -153,10 +152,10 @@ class TestLRU(unittest.TestCase):
     def test_has_key(self):
         for size in SIZES:
             l = LRU(size)
-            for i in range(2*size):
+            for i in range(2 * size):
                 l[i] = str(i)
                 self.assertTrue(l.has_key(i))
-            for i in range(size, 2*size):
+            for i in range(size, 2 * size):
                 self.assertTrue(l.has_key(i))
             for i in range(size):
                 self.assertFalse(l.has_key(i))
@@ -169,16 +168,16 @@ class TestLRU(unittest.TestCase):
     def test_capacity_set(self):
         for size in SIZES:
             l = LRU(size)
-            for i in range(size+5):
+            for i in range(size + 5):
                 l[i] = str(i)
-            l.set_size(size+10)
-            self.assertTrue(size+10 == l.get_size())
+            l.set_size(size + 10)
+            self.assertTrue(size + 10 == l.get_size())
             self.assertTrue(len(l) == size)
-            for i in range(size+20):
+            for i in range(size + 20):
                 l[i] = str(i)
-            self.assertTrue(len(l) == size+10)
-            l.set_size(size+10-1)
-            self.assertTrue(len(l) == size+10-1)
+            self.assertTrue(len(l) == size + 10)
+            l.set_size(size + 10 - 1)
+            self.assertTrue(len(l) == size + 10 - 1)
 
     def test_unhashable(self):
         l = LRU(1)
@@ -191,13 +190,13 @@ class TestLRU(unittest.TestCase):
     def test_clear(self):
         for size in SIZES:
             l = LRU(size)
-            for i in range(size+5):
+            for i in range(size + 5):
                 l[i] = str(i)
             l.clear()
             for i in range(size):
                 l[i] = str(i)
             for i in range(size):
-                _ = l[random.randint(0, size-1)]
+                _ = l[random.randint(0, size - 1)]
             l.clear()
             self.assertTrue(len(l) == 0)
 
@@ -312,7 +311,6 @@ class TestLRU(unittest.TestCase):
         self.assertEqual(l.keys(), ['b'])
         self.assertEqual(l.values(), [2])
 
-
         l = LRU(1, callback=callback)
         l[first_key] = first_value
 
@@ -333,8 +331,9 @@ class TestLRU(unittest.TestCase):
         self.assertEqual(counter[0], 1)
         self.assertEqual(l.keys(), ['b', 'a'])
         l.set_size(1)
-        self.assertEqual(counter[0], 2) # callback invoked
+        self.assertEqual(counter[0], 2)  # callback invoked
         self.assertEqual(l.keys(), ['b'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -222,6 +222,12 @@ class TestLRU(unittest.TestCase):
         self.assertEqual('2', val)
         self.assertEqual((1, 1), l.get_stats())
         self.assertEqual(val, l[2])
+        l.clear()
+        val = 'long string' * 512
+        l.setdefault(1, val)
+        l[2] = '2'
+        l[3] = '3'
+        self.assertTrue(val)
 
     def test_stats(self):
         for size in SIZES:

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -228,6 +228,31 @@ class TestLRU(unittest.TestCase):
         l[3] = '3'
         self.assertTrue(val)
 
+    def test_pop(self):
+        l = LRU(2)
+        v = '2' * 4096
+        l[1] = '1'
+        l[2] = v
+        val = l.pop(1)
+        self.assertEqual('1', val)
+        self.assertEqual((1, 0), l.get_stats())
+        val = l.pop(2, 'not used')
+        self.assertEqual(v, val)
+        del val
+        self.assertTrue(v)
+        self.assertEqual((2, 0), l.get_stats())
+        val = l.pop(3, '3' * 4096)
+        self.assertEqual('3' * 4096, val)
+        self.assertEqual((2, 1), l.get_stats())
+        self.assertEqual(0, len(l))
+        with self.assertRaises(KeyError) as ke:
+            l.pop(4)
+            self.assertEqual(4, ke.args[0])
+        self.assertEqual((2, 2), l.get_stats())
+        self.assertEqual(0, len(l))
+        with self.assertRaises(TypeError):
+            l.pop()
+
     def test_stats(self):
         for size in SIZES:
             l = LRU(size)


### PR DESCRIPTION
The new `pop` method follows the semantics of `dict.pop()`.

Fixes issue #21.