### PR TITLE
Add mutex protection of internal critical section.

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -157,8 +157,14 @@ typedef struct {
 static void
 lru_acquire_lock(LRU *self)
 {
+    PyLockStatus status;
+
     if (self && self->lock) {
-	PyThread_acquire_lock(self->lock, WAIT_LOCK);
+	status = PyThread_acquire_lock(self->lock, WAIT_LOCK);
+	if (status == PY_LOCK_FAILURE) {
+	    PyErr_SetString(PyExc_RuntimeError, "unable to wait on lock");
+	    return;
+	}
     }
 }
 

--- a/lru.c
+++ b/lru.c
@@ -154,6 +154,15 @@ typedef struct {
 
 
 #ifdef WITH_THREAD
+
+#if PY_MAJOR_VERSION < 3
+typedef enum PyLockStatus {
+    PY_LOCK_FAILURE = 0,
+    PY_LOCK_ACQUIRED = 1,
+    PY_LOCK_INTR
+} PyLockStatus;
+#endif	/* Python 2.7 compatibility */
+
 static void
 lru_acquire_lock(LRU *self)
 {


### PR DESCRIPTION
A mutex (Python lock) is added for the protection of the internal state.
Access to the internal data by the call to a Python-facing method is
done in a single pass through the critical section.

The callback, in contrast, will only be executed outside the critical
section. Inside the critical section, if a callback is set, cache
eviction will transfer the evicted objects into a staging area without
directly triggering the callback. Then, after exiting the critical
section, the staging area is purged by the callback.

In addition, some bugfixes are done.