### PR TITLE
BUG: refcount leak in popitem.

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -501,7 +501,6 @@ LRU_popitem(LRU *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
     lru_ass_sub(self, PyTuple_GET_ITEM(result, 0), NULL);
-    Py_INCREF(result);
     return result;
 }
 

--- a/lru.c
+++ b/lru.c
@@ -625,7 +625,7 @@ static PyMethodDef LRU_methods[] = {
                     PyDoc_STR("L.setdefault(key, default=None) -> If L has key return its value, otherwise insert key with a value of default and return default")},
     {"pop", (PyCFunction)LRU_pop, METH_VARARGS,
                     PyDoc_STR("L.pop(key[, default]) -> If L has key return its value and remove it from L, otherwise return default. If default is not given and key is not in L, a KeyError is raised.")},
-    {"popitem", (PyCFunctionWithKeywords)LRU_popitem, METH_VARARGS | METH_KEYWORDS,
+    {"popitem", (PyCFunction)LRU_popitem, METH_VARARGS | METH_KEYWORDS,
                     PyDoc_STR("L.popitem([least_recent=True]) -> Returns and removes a (key, value) pair. The pair returned is the least-recently used if least_recent is true, or the most-recently used if false.")},
     {"set_size", (PyCFunction)LRU_set_size, METH_VARARGS,
                     PyDoc_STR("L.set_size() -> set size of LRU")},

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -268,6 +268,17 @@ class TestLRU(unittest.TestCase):
             self.assertEqual('popitem(): LRU dict is empty', ke.args[0])
         self.assertEqual((0, 0), l.get_stats())
 
+    def test_popitem_refcount(self):
+        l = LRU(1)
+        value = "A Pythong string"
+        rc_before = sys.getrefcount(value)
+        l[0] = value
+        rc_after_insertion = sys.getrefcount(value)
+        l.popitem()
+        rc_after_popitem = sys.getrefcount(value)
+        self.assertGreater(rc_after_insertion, rc_before)
+        self.assertEqual(rc_after_popitem, rc_before)
+
     def test_stats(self):
         for size in SIZES:
             l = LRU(size)


### PR DESCRIPTION
This fixes a spurious increase of refcount to the Python tuple returned by the `popitem()` method. The tuple already gets new reference from `PyTuple_New()`.

Examples below:

```python
import sys
from lru import LRU


value = "A Python string"
r = LRU(10)
refcount = sys.getrefcount(value)
print("refcount before: %d" % refcount)
r[0] = value
refcount = sys.getrefcount(value)
print("refcount after insertion: %d" % refcount)
r.popitem()
refcount = sys.getrefcount(value)
print("refcount after popitem: %d" % refcount)
```

**before**

    refcount before: 4
    refcount after insertion: 5
    refcount after popitem: 5

**after**

    refcount before: 4
    refcount after insertion: 5
    refcount after popitem: 4
