### PR TITLE
Ensure the callback is called outside the critical section.

### DIFF
--- a/lru.c
+++ b/lru.c
@@ -30,6 +30,20 @@
  *  self->first will point to the MRU item and self-last to LRU item. Size of list will not
  *  grow beyond size of LRU dict.
  *
+ *  NOTE: No matter whether threading/locking is used internally in the
+ *  implementation of LRU, the concept of critical section is relevant, in
+ *  particular in the presence of the callback. The callback should not be
+ *  allowed to execute inside the critical section where the internal data is
+ *  being modified. Instead, the evicted objects are temporarily stored in a
+ *  staging list, which is purged when necessary, during which the callback is
+ *  called.
+ *
+ *  Here, the functions beginning with capital-letter "LRU_" are meant to be
+ *  exposed to Python as methods. The small-letter "lru_" functions are
+ *  implementation details and they will operate within the critical section.
+ *  Ideally, each method function should leave the critical section, and only
+ *  after that shall it trigger purging.
+ *
  */
 
 #ifndef Py_TYPE
@@ -128,8 +142,14 @@ typedef struct {
     Py_ssize_t hits;
     Py_ssize_t misses;
     PyObject *callback;
+    PyObject *staging_list;
+    char purge_flag;
 } LRU;
 
+/* The pair of macros currently do nothing. They simply add annotation in the
+ * source of the LRU_* method functions. */
+#define LRU_ENTER_CRITICAL
+#define LRU_LEAVE_CRITICAL
 
 static PyObject *
 set_callback(LRU *self, PyObject *args)
@@ -191,23 +211,67 @@ lru_add_node_at_head(LRU *self, Node* node)
 static void
 lru_delete_last(LRU *self)
 {
-    PyObject *arglist;
-    PyObject *result;
     Node* n = self->last;
-
-    if (!self->last)
+    if (n == NULL)
         return;
 
-    if (self->callback) {
-        
-        arglist = Py_BuildValue("OO", n->key, n->value);
-        result = PyObject_CallObject(self->callback, arglist);
-        Py_XDECREF(result);
-        Py_DECREF(arglist);
+    /* Transfer the node to staging. */
+    if (self->callback && self->staging_list) {
+	/* The list will increase the refcount to the node if successful */
+	if (PyList_Append(self->staging_list, (PyObject *)n) != -1)
+	    self->purge_flag |= 1;	/* set "to-purge" flag */
     }
 
     lru_remove_node(self, n);
     PUT_NODE(self->dict, n->key, NULL);
+}
+
+
+static void
+lru_purge_staging(LRU *self)
+{
+    /* Purging mechanism.
+     *
+     * NOTE: This is _the_ place where callback gets called. The function is
+     * intended to be always called _outside_ the critical section. The reason
+     * is that we cannot guarantee the callback function, which can do
+     * anything, will play nice with the LRU object itself. If the callback
+     * were executed within the critical section where/while the LRU internal
+     * data is not consistent, the inconsistency can be exposed.
+     *
+     * The staging area is just a Python list, and if a callback is set, it is
+     * called along the list in ascending index order. Then the list elements
+     * are wiped.
+     */
+    if (!self->purge_flag)
+	return;
+    self->purge_flag = 0;
+    if (self->staging_list) {
+	Py_ssize_t len = PyList_Size(self->staging_list);
+
+	if (self->callback != NULL) {
+	    Py_ssize_t i;
+	    for (i = 0; i < len; i++) {
+		Node *args;
+
+		/* new reference */
+		args = (Node *)PySequence_GetItem(self->staging_list, i);
+
+		if (args) {
+		    PyObject *result;
+		    result = PyObject_CallFunction(self->callback,
+			    "OO", args->key, args->value);
+		    Py_XDECREF(result);
+		} else {
+		    PyErr_Clear();
+		}
+		/* dispose of new reference */
+		Py_XDECREF(args);
+	    }
+	}
+	if (PySequence_DelSlice(self->staging_list, 0, len) == -1)
+	    PyErr_Clear();
+    }
 }
 
 static Py_ssize_t
@@ -216,15 +280,27 @@ lru_length(LRU *self)
     return PyDict_Size(self->dict);
 }
 
+/* Currently the public method is the same as the private implementation. */
+#define LRU_length	lru_length
+
 static PyObject *
 LRU_contains_key(LRU *self, PyObject *key)
 {
-    if (PyDict_Contains(self->dict, key)) {
+    int flag;
+
+    LRU_ENTER_CRITICAL;
+    flag = PyDict_Contains(self->dict, key);
+    LRU_LEAVE_CRITICAL;
+
+    if (flag == 1) {
         Py_RETURN_TRUE;
-    } else {
+    } else if (flag == 0) {
         Py_RETURN_FALSE;
+    } else {
+	return NULL;
     }
 }
+
 
 static PyObject *
 LRU_contains(LRU *self, PyObject *args)
@@ -238,7 +314,13 @@ LRU_contains(LRU *self, PyObject *args)
 static int
 LRU_seq_contains(LRU *self, PyObject *key)
 {
-    return PyDict_Contains(self->dict, key);
+    int res;
+
+    LRU_ENTER_CRITICAL;
+    res = PyDict_Contains(self->dict, key);
+    LRU_LEAVE_CRITICAL;
+
+    return res;
 }
 
 static PyObject *
@@ -264,6 +346,20 @@ lru_subscript(LRU *self, register PyObject *key)
     return node->value;
 }
 
+
+static PyObject *
+LRU_subscript(LRU *self, register PyObject *key)
+{
+    PyObject *result;
+
+    LRU_ENTER_CRITICAL;
+    result = lru_subscript(self, key);
+    LRU_LEAVE_CRITICAL;
+
+    return result;
+}
+
+
 static PyObject *
 LRU_get(LRU *self, PyObject *args)
 {
@@ -274,8 +370,13 @@ LRU_get(LRU *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O|O", &key, &instead))
         return NULL;
 
+    LRU_ENTER_CRITICAL;
+
     result = lru_subscript(self, key);
+
     PyErr_Clear();  /* GET_NODE sets an exception on miss. Shut it up. */
+    LRU_LEAVE_CRITICAL;
+
     if (result)
         return result;
 
@@ -334,10 +435,26 @@ lru_ass_sub(LRU *self, PyObject *key, PyObject *value)
     return res;
 }
 
+
+static int
+LRU_ass_sub(LRU *self, PyObject *key, PyObject *value)
+{
+    int res;
+
+    LRU_ENTER_CRITICAL;
+    res = lru_ass_sub(self, key, value);
+    LRU_LEAVE_CRITICAL;
+    /* This is an assignment method and may trigger eviction */
+    lru_purge_staging(self);
+
+    return res;
+}
+
+
 static PyMappingMethods LRU_as_mapping = {
-    (lenfunc)lru_length,        /*mp_length*/
-    (binaryfunc)lru_subscript,  /*mp_subscript*/
-    (objobjargproc)lru_ass_sub, /*mp_ass_subscript*/
+    (lenfunc)LRU_length,	/*mp_length*/
+    (binaryfunc)LRU_subscript,	/*mp_subscript*/
+    (objobjargproc)LRU_ass_sub,	/*mp_ass_subscript*/
 };
 
 static PyObject *
@@ -370,23 +487,29 @@ get_key(Node *node)
 static PyObject *
 LRU_update(LRU *self, PyObject *args, PyObject *kwargs)
 {
-	PyObject *key, *value;
-	PyObject *arg = NULL;
-	Py_ssize_t pos = 0;
+    PyObject *key, *value;
+    PyObject *arg = NULL;
+    Py_ssize_t pos = 0;
 
-	if ((PyArg_ParseTuple(args, "|O", &arg))) {
-		if (arg && PyDict_Check(arg)) {
-			while (PyDict_Next(arg, &pos, &key, &value))
-				lru_ass_sub(self, key, value);
-		}
-	}
-	
-	if (kwargs != NULL && PyDict_Check(kwargs)) {
-		while (PyDict_Next(kwargs, &pos, &key, &value))
-			lru_ass_sub(self, key, value);
-	}
+    LRU_ENTER_CRITICAL;
 
-	Py_RETURN_NONE;
+    if (PyArg_ParseTuple(args, "|O", &arg)) {
+	if (arg && PyDict_Check(arg)) {
+	    while (PyDict_Next(arg, &pos, &key, &value))
+		lru_ass_sub(self, key, value);
+	}
+    }
+
+    if (kwargs != NULL && PyDict_Check(kwargs)) {
+	while (PyDict_Next(kwargs, &pos, &key, &value))
+	    lru_ass_sub(self, key, value);
+    }
+
+    LRU_LEAVE_CRITICAL;
+    /* This is an assignment method and may trigger eviction */
+    lru_purge_staging(self);
+
+    Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -395,20 +518,32 @@ LRU_setdefault(LRU *self, PyObject *args)
     PyObject *key;
     PyObject *default_obj = NULL;
     PyObject *result;
+    int status;
 
     if (!PyArg_ParseTuple(args, "O|O", &key, &default_obj))
         return NULL;
 
+    LRU_ENTER_CRITICAL;
+
     result = lru_subscript(self, key);
+
+    if (result) {
+	LRU_LEAVE_CRITICAL;
+	return result;
+    }
+
     PyErr_Clear();
-    if (result)
-        return result;
-
     if (!default_obj)
-        default_obj = Py_None;
+	default_obj = Py_None;
 
-    if (lru_ass_sub(self, key, default_obj) != 0)
-        return NULL;
+    status = lru_ass_sub(self, key, default_obj);
+
+    LRU_LEAVE_CRITICAL;
+    /* This code branch may trigger eviction by adding a new key. */
+    lru_purge_staging(self);
+
+    if (status != 0)
+	return NULL;
 
     Py_INCREF(default_obj);
     return default_obj;
@@ -424,6 +559,7 @@ LRU_pop(LRU *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O|O", &key, &default_obj))
         return NULL;
 
+    LRU_ENTER_CRITICAL;
     /* Trying to access the item by key. */
     result = lru_subscript(self, key);
 
@@ -440,36 +576,62 @@ LRU_pop(LRU *self, PyObject *args)
      * call to lru_subscript (at the location marked by "Trying to access the
      * item by key" in the comments) has already generated the appropriate
      * exception. */
+    LRU_LEAVE_CRITICAL;
+    /* the pop() method never increases the cache size, and purging is not
+     * necessary even in the case of eager purging. */
+
+    return result;
+}
+
+
+static PyObject *
+get_item(Node *node)
+{
+    PyObject *tuple = PyTuple_New(2);
+    Py_INCREF(node->key);
+    PyTuple_SET_ITEM(tuple, 0, node->key);
+    Py_INCREF(node->value);
+    PyTuple_SET_ITEM(tuple, 1, node->value);
+    return tuple;
+}
+
+
+static PyObject *
+LRU_peek_first_item(LRU *self)
+{
+    PyObject *result;
+
+    LRU_ENTER_CRITICAL;
+
+    if (self->first) {
+	result = get_item(self->first);	/* New reference */
+    } else {
+	result = Py_None;
+	Py_INCREF(result);
+    }
+
+    LRU_LEAVE_CRITICAL;
 
     return result;
 }
 
 static PyObject *
-LRU_peek_first_item(LRU *self)
-{
-    if (self->first) {
-        PyObject *tuple = PyTuple_New(2);
-        Py_INCREF(self->first->key);
-        PyTuple_SET_ITEM(tuple, 0, self->first->key);
-        Py_INCREF(self->first->value);
-        PyTuple_SET_ITEM(tuple, 1, self->first->value);
-        return tuple;
-    }
-    else Py_RETURN_NONE;
-}
-
-static PyObject *
 LRU_peek_last_item(LRU *self)
 {
+    PyObject *result;
+
+    LRU_ENTER_CRITICAL;
+
     if (self->last) {
-        PyObject *tuple = PyTuple_New(2);
-        Py_INCREF(self->last->key);
-        PyTuple_SET_ITEM(tuple, 0, self->last->key);
-        Py_INCREF(self->last->value);
-        PyTuple_SET_ITEM(tuple, 1, self->last->value);
-        return tuple;
+        result = get_item(self->last);	/* New reference */
+    } else {
+	result = Py_None;
+	Py_INCREF(result);
     }
-    else Py_RETURN_NONE;
+
+    LRU_LEAVE_CRITICAL;
+
+    return result;
 }
 
 static PyObject *
@@ -477,7 +639,8 @@ LRU_popitem(LRU *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"least_recent", NULL};
     int pop_least_recent = 1;
-    PyObject *result;
+    PyObject *item_to_pop;	/* Python tuple of (key, value) */
+    Node *node;
 
 #if PY_MAJOR_VERSION >= 3
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|p", kwlist, &pop_least_recent))
@@ -492,22 +655,33 @@ LRU_popitem(LRU *self, PyObject *args, PyObject *kwds)
             return NULL;
     }
 #endif
-    if (pop_least_recent)
-        result = LRU_peek_last_item(self);
-    else
-        result = LRU_peek_first_item(self);
-    if (result == Py_None) {
-        PyErr_SetString(PyExc_KeyError, "popitem(): LRU dict is empty");
-        return NULL;
+    LRU_ENTER_CRITICAL;
+
+    node = pop_least_recent ? self->last : self->first;
+    /* item_to_pop is new reference if not NULL */
+    item_to_pop = node ? get_item(node) : NULL;
+    if (item_to_pop == NULL) {
+	PyErr_SetString(PyExc_KeyError, "popitem(): LRU dict is empty");
+	LRU_LEAVE_CRITICAL;
+	return NULL;
     }
-    lru_ass_sub(self, PyTuple_GET_ITEM(result, 0), NULL);
-    Py_INCREF(result);
-    return result;
+    lru_ass_sub(self, PyTuple_GET_ITEM(item_to_pop, 0), NULL);
+
+    LRU_LEAVE_CRITICAL;
+    /* No purging necessary as this will not add new items to LRU */
+
+    return item_to_pop;
 }
 
 static PyObject *
 LRU_keys(LRU *self) {
-    return collect(self, get_key);
+    PyObject * result;
+
+    LRU_ENTER_CRITICAL;
+    result = collect(self, get_key);
+    LRU_LEAVE_CRITICAL;
+
+    return result;
 }
 
 static PyObject *
@@ -520,36 +694,45 @@ get_value(Node *node)
 static PyObject *
 LRU_values(LRU *self)
 {
-    return collect(self, get_value);
+    PyObject * result;
+
+    LRU_ENTER_CRITICAL;
+    result = collect(self, get_value);
+    LRU_LEAVE_CRITICAL;
+
+    return result;
 }
 
 static PyObject *
 LRU_set_callback(LRU *self, PyObject *args)
 {
-    return set_callback(self, args);
+    PyObject *result;
+
+    LRU_ENTER_CRITICAL;
+    result = set_callback(self, args);
+    LRU_LEAVE_CRITICAL;
+
+    return result;
 }
 
-static PyObject *
-get_item(Node *node)
-{
-    PyObject *tuple = PyTuple_New(2);
-    Py_INCREF(node->key);
-    PyTuple_SET_ITEM(tuple, 0, node->key);
-    Py_INCREF(node->value);
-    PyTuple_SET_ITEM(tuple, 1, node->value);
-    return tuple;
-}
 
 static PyObject *
 LRU_items(LRU *self)
 {
-    return collect(self, get_item);
+    PyObject * result;
+
+    LRU_ENTER_CRITICAL;
+    result = collect(self, get_item);
+    LRU_LEAVE_CRITICAL;
+
+    return result;
 }
 
 static PyObject *
 LRU_set_size(LRU *self, PyObject *args, PyObject *kwds)
 {
     Py_ssize_t newSize;
+
     if (!PyArg_ParseTuple(args, "n", &newSize)) {
         return NULL;
     }
@@ -557,18 +740,28 @@ LRU_set_size(LRU *self, PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_ValueError, "Size should be a positive number");
         return NULL;
     }
+
+    LRU_ENTER_CRITICAL;
+
     while (lru_length(self) > newSize) {
         lru_delete_last(self);
     }
     self->size = newSize;
+
+    LRU_LEAVE_CRITICAL;
+    lru_purge_staging(self);
+
     Py_RETURN_NONE;
 }
 
 static PyObject *
 LRU_clear(LRU *self)
 {
-    Node *c = self->first;
+    Node *c;
 
+    LRU_ENTER_CRITICAL;
+
+    c = self->first;
     while (c) {
         Node* n = c;
         c = c->next;
@@ -578,6 +771,10 @@ LRU_clear(LRU *self)
 
     self->hits = 0;
     self->misses = 0;
+
+    LRU_LEAVE_CRITICAL;
+    lru_purge_staging(self);
+
     Py_RETURN_NONE;
 }
 
@@ -585,13 +782,25 @@ LRU_clear(LRU *self)
 static PyObject *
 LRU_get_size(LRU *self)
 {
-    return Py_BuildValue("i", self->size);
+    PyObject *res;
+
+    LRU_ENTER_CRITICAL;
+    res = Py_BuildValue("i", self->size);
+    LRU_LEAVE_CRITICAL;
+
+    return res;
 }
 
 static PyObject *
 LRU_get_stats(LRU *self)
 {
-    return Py_BuildValue("nn", self->hits, self->misses);
+    PyObject *res;
+
+    LRU_ENTER_CRITICAL;
+    res = Py_BuildValue("nn", self->hits, self->misses);
+    LRU_LEAVE_CRITICAL;
+
+    return res;
 }
 
 
@@ -626,7 +835,7 @@ static PyMethodDef LRU_methods[] = {
                     PyDoc_STR("L.setdefault(key, default=None) -> If L has key return its value, otherwise insert key with a value of default and return default")},
     {"pop", (PyCFunction)LRU_pop, METH_VARARGS,
                     PyDoc_STR("L.pop(key[, default]) -> If L has key return its value and remove it from L, otherwise return default. If default is not given and key is not in L, a KeyError is raised.")},
-    {"popitem", (PyCFunctionWithKeywords)LRU_popitem, METH_VARARGS | METH_KEYWORDS,
+    {"popitem", (PyCFunction)LRU_popitem, METH_VARARGS | METH_KEYWORDS,
                     PyDoc_STR("L.popitem([least_recent=True]) -> Returns and removes a (key, value) pair. The pair returned is the least-recently used if least_recent is true, or the most-recently used if false.")},
     {"set_size", (PyCFunction)LRU_set_size, METH_VARARGS,
                     PyDoc_STR("L.set_size() -> set size of LRU")},
@@ -680,6 +889,8 @@ LRU_init(LRU *self, PyObject *args, PyObject *kwds)
     self->first = self->last = NULL;
     self->hits = 0;
     self->misses = 0;
+    self->staging_list = PyList_New(0);
+    self->purge_flag = 0;
     return 0;
 }
 
@@ -687,10 +898,11 @@ static void
 LRU_dealloc(LRU *self)
 {
     if (self->dict) {
-        LRU_clear(self);
+        LRU_clear(self);	/* Will call callback on any staging elems. */
         Py_DECREF(self->dict);
-        Py_XDECREF(self->callback);
     }
+    Py_XDECREF(self->staging_list);
+    Py_XDECREF(self->callback);
     PyObject_Del((PyObject*)self);
 }
 


### PR DESCRIPTION
This patch is intended to address some of the problems discussed in #22 and #33. As @amitdev stated in https://github.com/amitdev/lru-dict/pull/32#issuecomment-772288310, there is currently no plan to add full-scale threading support. Meanwhile, thread safety can be improved by simply not allowing the callback to execute while the LRU is modifying its own internal structure. This will reduce the chance of the callback causing misery by interacting with the GIL or accessing the LRU itself.

The patch changes the working of the LRU-eviction code. If callback is set, a node that is to be evicted is appended to an internal Python list object, and a "should purge" flag is set. In methods that may trigger eviction, the "should purge" flag is checked and purge is executed if necessary. Purging is, by protocol, never executed in a critical section.

In a single-thread program, overall data integrity should be improved. Benchmark shows no noticeable performance drop without the callback, for there's little overhead if no callback is set. If the callback is contended frequently, my rough estimate shows about a ~20% speed drop, but with this penalty the speed is still about 90% faster than `pylru.lrucache` (which seems to also execute the callback eagerly as of its current HEAD), and is now much safer than before.

I also added a threaded test that uses to cause crash but now passes without problems (at least on my computer and Travis builds on Linux).

Some refactoring of methods is also done in the patch (duplicate-code removal, separation of Python-facing methods and internal implementation functions, etc.). This also incorporates the fix for the leak in #34.