### PR TITLE
:construction_worker: Wheels build, refs #23

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,34 @@
+name: Build and deploy
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v3
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.7.0
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist
+        run: pipx run build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@
 .. image:: https://github.com/amitdev/lru-dict/actions/workflows/tests.yml/badge.svg
     :target: https://github.com/amitdev/lru-dict/actions/workflows/tests.yml
 
+.. image:: https://github.com/amitdev/lru-dict/actions/workflows/build-and-deploy.yml/badge.svg
+    :target: https://github.com/amitdev/lru-dict/actions/workflows/build-and-deploy.yml
+
 LRU Dict
 ========
 


### PR DESCRIPTION
Leverages `cibuildwheel` to build wheels for different platforms
and Python versions then upload them as GitHub Artifact.
Note that it significantly increases the build time from instant to
about 5-8 minutes.
Follow up pull request will use the artifacts to publish to PyPI, refs:
https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/