### PR TITLE
Remove incref call from `LRU_popiten`

### DIFF
--- a/src/lru/_lru.c
+++ b/src/lru/_lru.c
@@ -494,6 +494,7 @@ LRU_popitem(LRU *self, PyObject *args, PyObject *kwds)
             return NULL;
     }
 #endif
+    // NOTE: `LRU_peek_*` increases `result` refcnt before returning it.
     if (pop_least_recent)
         result = LRU_peek_last_item(self);
     else
@@ -503,7 +504,6 @@ LRU_popitem(LRU *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
     lru_ass_sub(self, PyTuple_GET_ITEM(result, 0), NULL);
-    Py_INCREF(result);
     return result;
 }
 


### PR DESCRIPTION
The `result` object already gets its count increased inside `LRU_peek_*_item`, so doing it twice causes a memory leak.
Should fix #64 