### PR TITLE
Add Android to build/deploy matrix

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        os: [linux, windows, macos, ios]
+        os: [linux, windows, macos, ios, android]
         include:
           - os: linux
             runs-on: ubuntu-22.04
@@ -18,6 +18,8 @@ jobs:
             runs-on: macos-latest
           - os: ios
             runs-on: macos-latest
+          - os: android
+            runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -26,15 +28,22 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+      - name: Enable KVM group perms
+        if: matrix.os == 'android'
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
       # Used to host cibuildwheel
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.1.2
         env:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones
           CIBW_PLATFORM: ${{ matrix.os }}
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
           CIBW_ARCHS_IOS: arm64_iphoneos arm64_iphonesimulator x86_64_iphonesimulator
+          CIBW_ARCHS_ANDROID: x86_64 arm64_v8a
           # cannot test the arm64 part for CPython 3.8 universal2/arm64, see https://github.com/pypa/cibuildwheel/pull/1169
           CIBW_TEST_SKIP: cp38-macosx_arm64
           # pypy will need to be enabled for cibuildwheel 3
@@ -65,7 +74,7 @@ jobs:
     - uses: actions/setup-python@v5
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        pattern: artifacts-*
         path: dist
         merge-multiple: true
     - name: Publish package

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           - os: macos
             runs-on: macos-latest
           - os: ios
-            runs-on: macos-latest
+            runs-on: macos-14
           - os: android
             runs-on: ubuntu-latest
 
@@ -36,7 +36,7 @@ jobs:
             sudo udevadm trigger --name-match=kvm
       # Used to host cibuildwheel
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.2
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones
           CIBW_PLATFORM: ${{ matrix.os }}


### PR DESCRIPTION
cibuildwheel 3.1.2 includes support for building Android wheels, as well as adding Python 3.14 as platform that is built by default.

This PR adds Android to the build and deploy matrix. Testing Android wheels requires an VM configuration to enable KVM group permissions so that the emulator can run. 

It also corrects an issue with the release workflow that was introduced by #73, and subsequently modified by 424b85ba. As multiple artifacts are created (and none of them are named `artifact`), a single `name: artifact` download action won't work; the workflow needs to use a pattern of `artifacts-*` to download all artifacts.

/cc @mhsmith (cibuildwheel Android platform maintainer).
